### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/components/DocuSignSettings.vue
+++ b/src/components/DocuSignSettings.vue
@@ -102,7 +102,7 @@ export default {
 	},
 
 	mounted() {
-		const paramString = window.location.search.substr(1)
+		const paramString = window.location.search.slice(1)
 		// eslint-disable-next-line
 		const urlParams = new URLSearchParams(paramString)
 		const dsToken = urlParams.get('docusignToken')


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.