### PR TITLE
Fix file being shared with approver group even if the group already has access

### DIFF
--- a/lib/Service/ApprovalService.php
+++ b/lib/Service/ApprovalService.php
@@ -582,7 +582,7 @@ class ApprovalService {
 		}
 		if ($this->shareManager->allowGroupSharing()) {
 			foreach ($rule['approvers'] as $approver) {
-				if ($approver['type'] === 'group') {
+				if ($approver['type'] === 'group' && !$this->utilsService->groupHasAccessTo($fileId, $approver['entityId'])) {
 					if ($this->utilsService->createShare($node, IShare::TYPE_GROUP, $approver['entityId'], $fileOwner, $label)) {
 						$createdShares[] = $approver;
 					}


### PR DESCRIPTION
When requesting approval with a rule having a group as "approver", the file is always shared with this group to make sure the group has access.

Two problems:
1. The group might already have access (via a file share or through a group folder) and we create an unnecessary file share
2. The group does not have access but some of its members have access. Those users will receive access with the group share we create but they already had access.

This PR kind of fixes 1.
We only create the file share to the group if at least one member of this group does not have access to the file.

Iterating over group members to check if they have access is not ideal performance-wise.
@skjnldsv Is there a more efficient way to check if a group has access to a file (via a group folder, a file share or anything else)?

cc @blizzz 