### PR TITLE
optimize propfind plugins

### DIFF
--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit
-          extensions: mbstring, iconv, fileinfo, intl, mysql, pdo_mysql
+          extensions: mbstring, iconv, fileinfo, intl, mysql, pdo_mysql, gd
           coverage: none
 
       - name: Check composer file existence

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -74,7 +74,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, fileinfo, intl, sqlite, pdo_sqlite, oci8
+          extensions: mbstring, fileinfo, intl, sqlite, pdo_sqlite, oci8, gd
           tools: phpunit
           coverage: none
 

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit
-          extensions: mbstring, iconv, fileinfo, intl, pgsql, pdo_pgsql
+          extensions: mbstring, iconv, fileinfo, intl, pgsql, pdo_pgsql, gd
           coverage: none
 
       - name: Check composer file existence

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit
-          extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite
+          extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite, gd
           coverage: none
 
       - name: Check composer file existence

--- a/lib/Service/ApprovalService.php
+++ b/lib/Service/ApprovalService.php
@@ -321,10 +321,11 @@ class ApprovalService {
 	 * Get approval state of a given file for a given user
 	 * @param int $fileId
 	 * @param string|null $userId
+	 * @param bool $userHasAccessChecked whether we already checked if a user has access
 	 * @return array state and rule id
 	 */
-	public function getApprovalState(int $fileId, ?string $userId): array {
-		if (is_null($userId) || !$this->utilsService->userHasAccessTo($fileId, $userId)) {
+	public function getApprovalState(int $fileId, ?string $userId, bool $userHasAccessChecked = false): array {
+		if (is_null($userId) || !($userHasAccessChecked || $this->utilsService->userHasAccessTo($fileId, $userId))) {
 			return ['state' => Application::STATE_NOTHING];
 		}
 
@@ -858,11 +859,10 @@ class ApprovalService {
 			return;
 		}
 		$nodeId = $node->getId();
-		// get state
-		$state = $this->getApprovalState($nodeId, $this->userId);
 
 		$propFind->handle(
-			Application::DAV_PROPERTY_APPROVAL_STATE, function() use ($nodeId, $state) {
+			Application::DAV_PROPERTY_APPROVAL_STATE, function() use ($nodeId) {
+				$state = $this->getApprovalState($nodeId, $this->userId, true);
 				return $state['state'];
 			}
 		);


### PR DESCRIPTION
- don't get the state if it's not requested
- don't check if the user has access if we already know they do
- cache the list of rules

Saves [4 requests per file](https://blackfire.io/profiles/compare/b620b924-cfb0-412d-8683-ee71c38f0e80/graph) when propfinding a folder