### PR TITLE
Bump minor version digit to still be able to publish for 24

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>Approval</name>
 	<summary>Let users approve or reject files</summary>
 	<description><![CDATA[Approve/reject files based on workflows defined by admins.]]></description>
-	<version>1.0.14</version>
+	<version>1.1.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Approval</namespace>


### PR DESCRIPTION
ea11f6fac24669a22cef2df009f592f3c6b264ee bumped the min NC version without bumping the minor or major version digit.

Bump version to 1.1.0 as we may need to backport security stuff for 24 and still make releases.
* 1.0.x for NC 24
* 1.1.x for NC > 24

We could also bump the major version digit. No preference on my side.