### PR TITLE
Set min and max compatible NC to 24

### DIFF
--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ "8.0", "8.1", "8.2" ]
+        php-versions: [ "7.4", "8.0", "8.1" ]
 
     name: php-lint
 

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -38,8 +38,8 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2']
-        server-versions: ['master']
+        php-versions: ['7.4', '8.0', '8.1']
+        server-versions: ['stable24']
 
     services:
       mysql:

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.0']
-        server-versions: ['master']
+        server-versions: ['stable24']
 
     services:
       oracle:

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.0']
-        server-versions: ['master']
+        server-versions: ['stable24']
 
     services:
       postgres:

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.0']
-        server-versions: ['master']
+        server-versions: ['stable24']
 
     steps:
       - name: Set app env

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@
 	<screenshot>https://github.com/nextcloud/approval/raw/main/img/screenshot_2.jpg</screenshot>
 	<screenshot>https://github.com/nextcloud/approval/raw/main/img/screenshot_3.jpg</screenshot>
 	<dependencies>
-		<nextcloud min-version="25" max-version="28"/>
+		<nextcloud min-version="24" max-version="24"/>
 	</dependencies>
 	<settings>
 		<admin>OCA\Approval\Settings\Admin</admin>


### PR DESCRIPTION
Even if v1.0.14 dropped support for NC 24, I think we can base stable24 on the v1.0.14 tag so we have the recent optimizations in.
So this sets the min and max NC version to 24 for stable24.
v1.0.15 will be for NC 24 and v1.1.0 for NC >= 25.

@skjnldsv There was no strong reason to drop 24 support in ea11f6fac24669a22cef2df009f592f3c6b264ee, right?