### PR TITLE
Prepare v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 1.2.0 – 2023-12-22
+
+### Changed
+
+- reimplement the frontend for Nextcloud >= 28 [#114](https://github.com/nextcloud/approval/pull/114) @julien-nc
+- remove docusign/libresign related code
+
 ## 1.1.1 – 2023-11-29
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<description><![CDATA[
 Approve/reject files based on workflows defined by admins.
 ]]></description>
-	<version>1.1.1</version>
+	<version>1.2.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Approval</namespace>


### PR DESCRIPTION
### Changed

- reimplement the frontend for Nextcloud >= 28 [#114](https://github.com/nextcloud/approval/pull/114) @julien-nc
- remove docusign/libresign related code