### PR TITLE
Add file sidebar tab

### DIFF
--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2']
+        php-versions: ['8.1', '8.2', '8.3']
         server-versions: ['master']
 
     services:

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0']
+        php-versions: ['8.1']
         server-versions: ['master']
 
     services:

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0']
+        php-versions: ['8.1']
         server-versions: ['master']
 
     services:

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0']
+        php-versions: ['8.1']
         server-versions: ['master']
 
     steps:

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -12,10 +12,12 @@ namespace OCA\Approval\AppInfo;
 use OCA\Approval\Dashboard\ApprovalPendingWidget;
 use OCA\Approval\Dav\ApprovalPlugin;
 use OCA\Approval\Listener\LoadAdditionalScriptsListener;
+use OCA\Approval\Listener\LoadSidebarScripts;
 use OCA\Approval\Notification\Notifier;
 use OCA\Approval\Service\ApprovalService;
 
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
+use OCA\Files\Event\LoadSidebar;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -60,6 +62,7 @@ class Application extends App implements IBootstrap {
 
 	public function register(IRegistrationContext $context): void {
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, LoadAdditionalScriptsListener::class);
+		$context->registerEventListener(LoadSidebar::class, LoadSidebarScripts::class);
 		$context->registerNotifierService(Notifier::class);
 		$context->registerDashboardWidget(ApprovalPendingWidget::class);
 	}

--- a/lib/Listener/LoadSidebarScripts.php
+++ b/lib/Listener/LoadSidebarScripts.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @author Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Approval\Listener;
+
+use OCA\Approval\AppInfo\Application;
+use OCA\Files\Event\LoadSidebar;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Util;
+
+/** @template-implements IEventListener<LoadSidebar> */
+class LoadSidebarScripts implements IEventListener {
+
+	public function __construct(
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof LoadSidebar)) {
+			return;
+		}
+
+		Util::addScript(Application::APP_ID, Application::APP_ID . '-approvalTab', 'files');
+	}
+}

--- a/src/approvalTab.js
+++ b/src/approvalTab.js
@@ -1,0 +1,64 @@
+/**
+ * @copyright Copyright (c) 2024 Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @author Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import ApprovalSvgIcon from '../img/app-dark.svg'
+import { getRequestToken } from '@nextcloud/auth'
+import Vue from 'vue'
+import ApprovalTab from './views/ApprovalTab.vue'
+
+__webpack_nonce__ = btoa(getRequestToken()) // eslint-disable-line
+Vue.mixin({ methods: { t, n } })
+
+const View = Vue.extend(ApprovalTab)
+// Init approval tab component
+let TabInstance = null
+const approvalTab = new OCA.Files.Sidebar.Tab({
+	id: 'approval',
+	name: t('approval', 'Approval'),
+	iconSvg: ApprovalSvgIcon,
+
+	async mount(el, fileInfo, context) {
+		if (TabInstance) {
+			TabInstance.$destroy()
+		}
+		TabInstance = new View({
+			// Better integration with vue parent component
+			parent: context,
+		})
+		// Only mount after we have all the info we need
+		await TabInstance.update(fileInfo)
+		TabInstance.$mount(el)
+	},
+	update(fileInfo) {
+		TabInstance.update(fileInfo)
+	},
+	destroy() {
+		TabInstance.$destroy()
+		TabInstance = null
+	},
+})
+
+window.addEventListener('DOMContentLoaded', () => {
+	if (OCA.Files && OCA.Files.Sidebar) {
+		OCA.Files.Sidebar.registerTab(approvalTab)
+	}
+})

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -224,7 +224,7 @@ export default {
 					t('approval', 'Failed to get approval workflows')
 					+ ': ' + (error.response?.data?.error ?? error.response?.request?.responseText ?? ''),
 				)
-				console.debug(error)
+				console.error(error)
 			}).then(() => {
 				this.loadingRules = false
 			})
@@ -314,7 +314,7 @@ export default {
 						t('approval', 'Failed to create approval workflow')
 						+ ': ' + (error.response?.data?.error ?? error.response?.request?.responseText ?? ''),
 					)
-					console.debug(error)
+					console.error(error)
 				}).then(() => {
 					this.savingRule = false
 				})
@@ -330,7 +330,7 @@ export default {
 					t('approval', 'Failed to delete approval workflow')
 					+ ': ' + (error.response?.data?.error ?? error.response?.request?.responseText ?? ''),
 				)
-				console.debug(error)
+				console.error(error)
 			}).then(() => {
 			})
 		},
@@ -354,7 +354,7 @@ export default {
 						t('approval', 'Failed to create tag "{name}"', { name: this.newTagName })
 						+ ': ' + (error.response?.data?.error ?? error.response?.request?.responseText ?? ''),
 					)
-					console.debug(error)
+					console.error(error)
 				}).then(() => {
 					this.creatingTag = false
 				})

--- a/src/components/FilesRequestModal.vue
+++ b/src/components/FilesRequestModal.vue
@@ -1,0 +1,62 @@
+<template>
+	<RequestModal v-if="show"
+		:user-rules="userRules"
+		@request="onRequest"
+		@close="closeModal" />
+</template>
+
+<script>
+import RequestModal from './RequestModal.vue'
+
+export default {
+	name: 'FilesRequestModal',
+
+	components: {
+		RequestModal,
+	},
+
+	props: {
+	},
+
+	data() {
+		return {
+			show: false,
+			userRules: [],
+			node: null,
+		}
+	},
+
+	computed: {
+	},
+
+	watch: {
+	},
+
+	mounted() {
+	},
+
+	methods: {
+		showModal() {
+			this.show = true
+		},
+		closeModal() {
+			this.show = false
+			this.$emit('close')
+		},
+		setUserRules(rules) {
+			this.userRules = rules
+		},
+		setNode(node) {
+			this.node = node
+		},
+		onRequest(ruleId, createShares) {
+			this.closeModal()
+			this.$emit('request', this.node, ruleId, createShares)
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+// nothing
+</style>

--- a/src/components/Info.vue
+++ b/src/components/Info.vue
@@ -1,0 +1,266 @@
+<template>
+	<div class="info-content">
+		<ApprovalButtons v-if="stateApprovable"
+			class="buttons"
+			:approve-text="approveText"
+			:reject-text="rejectText"
+			@approve="onApprove"
+			@reject="onReject" />
+		<span v-if="stateApproved"
+			class="state-label approved-label">
+			<CheckCircleIcon class="approved" :size="32" />
+			<span v-if="userId && timestamp"
+				class="details">
+				<strong>{{ approvedByText }}</strong>
+				<NcUserBubble
+					class="user-bubble"
+					:user="userId"
+					:display-name="notMe ? userName : you"
+					:size="24" />
+				{{ relativeTime }}
+			</span>
+			<span v-else>{{ approvedText }}</span>
+		</span>
+		<span v-if="stateRejected"
+			class="state-label rejected-label">
+			<CloseCircleIcon class="rejected" :size="32" />
+			<span v-if="userId && timestamp"
+				class="details">
+				<strong>{{ rejectedByText }}</strong>
+				<NcUserBubble
+					class="user-bubble"
+					:user="userId"
+					:display-name="notMe ? userName : you"
+					:size="24" />
+				{{ relativeTime }}
+			</span>
+			<span v-else>{{ rejectedText }}</span>
+		</span>
+		<span v-if="statePending"
+			class="state-label pending-label">
+			<DotsHorizontalCircleIcon class="pending" :size="32" />
+			<span v-if="userId && timestamp"
+				class="details">
+				<strong>{{ requestedByText }}</strong>
+				<NcUserBubble
+					class="user-bubble"
+					:user="userId"
+					:display-name="notMe ? userName : you"
+					:size="24" />
+				{{ relativeTime }}
+			</span>
+			<span v-else>{{ pendingTextWithTime }}</span>
+		</span>
+		<NcButton v-if="canRequestApproval"
+			@click="onRequest">
+			<template #icon>
+				<CheckIcon :size="20" />
+			</template>
+			{{ t('approval', 'Request approval') }}
+		</NcButton>
+		<div class="info">
+			<span>{{ infoText }}</span>
+			<NcUserBubble v-if="stateApprovable && userName"
+				class="user-bubble"
+				:user="userId"
+				:display-name="notMe ? userName : you"
+				:size="24" />
+			<span>{{ ruleText }}</span>
+		</div>
+	</div>
+</template>
+
+<script>
+import CheckIcon from 'vue-material-design-icons/Check.vue'
+import CheckCircleIcon from 'vue-material-design-icons/CheckCircle.vue'
+import DotsHorizontalCircleIcon from 'vue-material-design-icons/DotsHorizontalCircle.vue'
+import CloseCircleIcon from 'vue-material-design-icons/CloseCircle.vue'
+
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcUserBubble from '@nextcloud/vue/dist/Components/NcUserBubble.js'
+
+import ApprovalButtons from './ApprovalButtons.vue'
+
+import { states } from '../states.js'
+
+import { getCurrentUser } from '@nextcloud/auth'
+import moment from '@nextcloud/moment'
+
+export default {
+	name: 'Info',
+
+	components: {
+		ApprovalButtons,
+		NcButton,
+		NcUserBubble,
+		CheckCircleIcon,
+		CloseCircleIcon,
+		CheckIcon,
+		DotsHorizontalCircleIcon,
+	},
+
+	props: {
+		state: {
+			type: Number,
+			required: true,
+		},
+		timestamp: {
+			type: [Number, null],
+			default: null,
+		},
+		userName: {
+			type: [String, null],
+			default: null,
+		},
+		userId: {
+			type: [String, null],
+			default: null,
+		},
+		rule: {
+			type: Object,
+			default: () => {},
+		},
+		userRules: {
+			type: Array,
+			required: true,
+		},
+		approveText: {
+			type: String,
+			default: t('approval', 'Approve'),
+		},
+		rejectText: {
+			type: String,
+			default: t('approval', 'Reject'),
+		},
+		approvedText: {
+			type: String,
+			default: t('approval', 'Approved'),
+		},
+		approvedByText: {
+			type: String,
+			default: t('approval', 'Approved by'),
+		},
+		rejectedText: {
+			type: String,
+			default: t('approval', 'Rejected'),
+		},
+		rejectedByText: {
+			type: String,
+			default: t('approval', 'Rejected by'),
+		},
+		requestedByText: {
+			type: String,
+			default: t('approval', 'Approval requested by'),
+		},
+		pendingText: {
+			type: String,
+			default: t('approval', 'Approval requested'),
+		},
+	},
+
+	data() {
+		return {
+			you: t('approval', 'you'),
+		}
+	},
+
+	computed: {
+		pendingTextWithTime() {
+			return this.timestamp
+				? this.pendingText + ' ' + this.relativeTime
+				: this.pendingText
+		},
+		stateApproved() {
+			return this.state === states.APPROVED
+		},
+		stateRejected() {
+			return this.state === states.REJECTED
+		},
+		statePending() {
+			return this.state === states.PENDING
+		},
+		stateApprovable() {
+			return this.state === states.APPROVABLE
+		},
+		relativeTime() {
+			return moment.unix(this.timestamp).fromNow()
+		},
+		notMe() {
+			return this.userId !== getCurrentUser().uid
+		},
+		canRequestApproval() {
+			return this.userRules.length > 0
+		},
+		ruleText() {
+			if ([states.APPROVED, states.PENDING, states.REJECTED, states.APPROVABLE].includes(this.state)) {
+				return t('approval', 'The related approval workflow is: {ruleDescription}', { ruleDescription: this.rule.description })
+			}
+			return ''
+		},
+		infoText() {
+			if (this.state === states.APPROVABLE) {
+				if (this.userName) {
+					return t('approval', 'This user requested your approval') + ': '
+				} else {
+					return t('approval', 'Your approval was requested.')
+				}
+			}
+			return ''
+		},
+	},
+
+	watch: {
+	},
+
+	mounted() {
+	},
+
+	methods: {
+		onApprove() {
+			this.$emit('approve')
+		},
+		onReject() {
+			this.$emit('reject')
+		},
+		onRequest() {
+			this.$emit('request')
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+.info-content {
+	padding: 16px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+	.state-label {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		.details {
+			display: flex;
+			align-items: center;
+			gap: 4px;
+		}
+	}
+
+	.buttons {
+		justify-content: center;
+	}
+
+	.approved {
+		color: var(--color-success);
+	}
+
+	.rejected {
+		color: var(--color-error);
+	}
+
+	.pending {
+		color: var(--color-warning);
+	}
+}
+</style>

--- a/src/components/InfoModal.vue
+++ b/src/components/InfoModal.vue
@@ -2,145 +2,37 @@
 	<NcModal v-if="show"
 		size="normal"
 		@close="closeModal">
-		<div class="info-modal-content">
-			<ApprovalButtons v-if="stateApprovable"
-				class="buttons"
-				:approve-text="approveText"
-				:reject-text="rejectText"
-				@approve="onApprove"
-				@reject="onReject" />
-			<span v-if="stateApproved"
-				class="state-label approved-label">
-				<CheckCircleIcon class="approved" :size="32" />
-				<span v-if="userId && timestamp"
-					class="details">
-					<strong>{{ approvedByText }}</strong>
-					<NcUserBubble
-						class="user-bubble"
-						:user="userId"
-						:display-name="notMe ? userName : you"
-						:size="24" />
-					{{ relativeTime }}
-				</span>
-				<span v-else>{{ approvedText }}</span>
-			</span>
-			<span v-if="stateRejected"
-				class="state-label rejected-label">
-				<CloseCircleIcon class="rejected" :size="32" />
-				<span v-if="userId && timestamp"
-					class="details">
-					<strong>{{ rejectedByText }}</strong>
-					<NcUserBubble
-						class="user-bubble"
-						:user="userId"
-						:display-name="notMe ? userName : you"
-						:size="24" />
-					{{ relativeTime }}
-				</span>
-				<span v-else>{{ rejectedText }}</span>
-			</span>
-			<span v-if="statePending"
-				class="state-label pending-label">
-				<CheckCircleIcon class="pending" :size="32" />
-				<span v-if="userId && timestamp"
-					class="details">
-					<strong>{{ requestedByText }}</strong>
-					<NcUserBubble
-						class="user-bubble"
-						:user="userId"
-						:display-name="notMe ? userName : you"
-						:size="24" />
-					{{ relativeTime }}
-				</span>
-				<span v-else>{{ pendingTextWithTime }}</span>
-			</span>
-			<NcButton v-if="canRequestApproval"
-				@click="onRequest">
-				<template #icon>
-					<CheckIcon :size="20" />
-				</template>
-				{{ t('approval', 'Request approval') }}
-			</NcButton>
-			<div class="info">
-				<span>{{ infoText }}</span>
-				<NcUserBubble v-if="stateApprovable && userName"
-					class="user-bubble"
-					:user="userId"
-					:display-name="notMe ? userName : you"
-					:size="24" />
-				<span>{{ ruleText }}</span>
-			</div>
-		</div>
+		<Info
+			:state="state"
+			:timestamp="timestamp"
+			:user-name="userName"
+			:user-id="userId"
+			:rule="rule"
+			:user-rules="userRules"
+			@approve="onApprove"
+			@reject="onReject"
+			@request="onRequest" />
 	</NcModal>
 </template>
 
 <script>
-import CheckIcon from 'vue-material-design-icons/Check.vue'
-import CheckCircleIcon from 'vue-material-design-icons/CheckCircle.vue'
-import CloseCircleIcon from 'vue-material-design-icons/CloseCircle.vue'
-
 import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
-import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import NcUserBubble from '@nextcloud/vue/dist/Components/NcUserBubble.js'
 
-import ApprovalButtons from './ApprovalButtons.vue'
-
-import { states } from '../states.js'
-
-import { getCurrentUser } from '@nextcloud/auth'
-import moment from '@nextcloud/moment'
+import Info from './Info.vue'
 
 export default {
 	name: 'InfoModal',
 
 	components: {
-		ApprovalButtons,
+		Info,
 		NcModal,
-		NcButton,
-		NcUserBubble,
-		CheckCircleIcon,
-		CloseCircleIcon,
-		CheckIcon,
 	},
 
 	props: {
-		approveText: {
-			type: String,
-			default: t('approval', 'Approve'),
-		},
-		rejectText: {
-			type: String,
-			default: t('approval', 'Reject'),
-		},
-		approvedText: {
-			type: String,
-			default: t('approval', 'Approved'),
-		},
-		approvedByText: {
-			type: String,
-			default: t('approval', 'Approved by'),
-		},
-		rejectedText: {
-			type: String,
-			default: t('approval', 'Rejected'),
-		},
-		rejectedByText: {
-			type: String,
-			default: t('approval', 'Rejected by'),
-		},
-		requestedByText: {
-			type: String,
-			default: t('approval', 'Approval requested by'),
-		},
-		pendingText: {
-			type: String,
-			default: t('approval', 'Approval requested'),
-		},
 	},
 
 	data() {
 		return {
-			you: t('approval', 'you'),
 			show: false,
 			node: null,
 			userRules: [],
@@ -162,48 +54,6 @@ export default {
 		},
 		rule() {
 			return this.node.attributes['approval-rule']
-		},
-		pendingTextWithTime() {
-			return this.timestamp
-				? this.pendingText + ' ' + this.relativeTime
-				: this.pendingText
-		},
-		stateApproved() {
-			return this.state === states.APPROVED
-		},
-		stateRejected() {
-			return this.state === states.REJECTED
-		},
-		statePending() {
-			return this.state === states.PENDING
-		},
-		stateApprovable() {
-			return this.state === states.APPROVABLE
-		},
-		relativeTime() {
-			return moment.unix(this.timestamp).fromNow()
-		},
-		notMe() {
-			return this.userId !== getCurrentUser().uid
-		},
-		canRequestApproval() {
-			return this.userRules.length > 0
-		},
-		ruleText() {
-			if ([states.APPROVED, states.PENDING, states.REJECTED, states.APPROVABLE].includes(this.state)) {
-				return t('approval', 'The related approval workflow is: {ruleDescription}', { ruleDescription: this.rule.description })
-			}
-			return ''
-		},
-		infoText() {
-			if (this.state === states.APPROVABLE) {
-				if (this.userName) {
-					return t('approval', 'This user requested your approval') + ': '
-				} else {
-					return t('approval', 'Your approval was requested.')
-				}
-			}
-			return ''
 		},
 	},
 
@@ -244,37 +94,5 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.info-modal-content {
-	padding: 16px;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 8px;
-	.state-label {
-		display: flex;
-		align-items: center;
-		gap: 4px;
-		.details {
-			display: flex;
-			align-items: center;
-			gap: 4px;
-		}
-	}
-
-	.buttons {
-		justify-content: center;
-	}
-
-	.approved {
-		color: var(--color-success);
-	}
-
-	.rejected {
-		color: var(--color-error);
-	}
-
-	.pending {
-		color: var(--color-warning);
-	}
-}
+// nothing yet
 </style>

--- a/src/components/RequestForm.vue
+++ b/src/components/RequestForm.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="request-modal">
+	<div class="request-form">
 		<h2>
 			{{ title }}
 		</h2>
@@ -114,7 +114,11 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.request-modal {
+.request-form {
+	>h2 {
+		margin-top: 0;
+	}
+
 	.rule-list {
 		display: flex;
 		flex-direction: column;

--- a/src/components/RequestModal.vue
+++ b/src/components/RequestModal.vue
@@ -25,13 +25,15 @@ export default {
 	},
 
 	props: {
+		userRules: {
+			type: Array,
+			required: true,
+		},
 	},
 
 	data() {
 		return {
-			show: false,
-			userRules: [],
-			node: null,
+			show: true,
 		}
 	},
 
@@ -45,24 +47,13 @@ export default {
 	},
 
 	methods: {
-		showModal() {
-			this.show = true
-		},
 		closeModal() {
 			this.show = false
 			this.$emit('close')
-			// this.reset()
-		},
-		setUserRules(rules) {
-			this.userRules = rules
-		},
-		setNode(node) {
-			this.node = node
 		},
 		onRequest(ruleId, createShares) {
 			this.closeModal()
-			this.$emit('request', this.node, ruleId, createShares)
-			// this.requesting = true
+			this.$emit('request', ruleId, createShares)
 		},
 	},
 }

--- a/src/files/actions/approveAction.js
+++ b/src/files/actions/approveAction.js
@@ -1,7 +1,7 @@
 import CheckCircleSvgIcon from '@mdi/svg/svg/check-circle.svg'
 import { Permission, FileAction } from '@nextcloud/files'
 import { states } from '../../states.js'
-import { onApproveAction } from '../helpers.js'
+import { approve } from '../helpers.js'
 
 export const approveAction = new FileAction({
 	id: 'approval-approve',
@@ -19,7 +19,7 @@ export const approveAction = new FileAction({
 	order: 0,
 	async exec(node) {
 		try {
-			await onApproveAction(node)
+			await approve(node.fileid, node.basename, node)
 		} catch (error) {
 			console.debug('Approve action failed')
 		}
@@ -28,7 +28,7 @@ export const approveAction = new FileAction({
 	async execBatch(nodes) {
 		const promises = nodes
 			.filter(node => node.attributes['approval-state'] === states.APPROVABLE)
-			.map(node => onApproveAction(node, false))
+			.map(node => approve(node.fileid, node.basename, node, false))
 		const results = await Promise.allSettled(promises)
 		return results.map(promise => promise.status === 'fulfilled')
 	},

--- a/src/files/actions/rejectAction.js
+++ b/src/files/actions/rejectAction.js
@@ -1,7 +1,7 @@
 import CloseCircleSvgIcon from '@mdi/svg/svg/close-circle.svg'
 import { states } from '../../states.js'
 import { Permission, FileAction } from '@nextcloud/files'
-import { onRejectAction } from '../helpers.js'
+import { reject } from '../helpers.js'
 
 export const rejectAction = new FileAction({
 	id: 'approval-reject',
@@ -19,7 +19,7 @@ export const rejectAction = new FileAction({
 	order: 0,
 	async exec(node) {
 		try {
-			await onRejectAction(node)
+			await reject(node.fileid, node.basename, node)
 		} catch (error) {
 			console.debug('Reject action failed')
 		}
@@ -28,7 +28,7 @@ export const rejectAction = new FileAction({
 	async execBatch(nodes) {
 		const promises = nodes
 			.filter(node => node.attributes['approval-state'] === states.APPROVABLE)
-			.map(node => onRejectAction(node, false))
+			.map(node => reject(node.fileid, node.basename, node, false))
 		const results = await Promise.allSettled(promises)
 		return results.map(promise => promise.status === 'fulfilled')
 	},

--- a/src/files/actions/requestAction.js
+++ b/src/files/actions/requestAction.js
@@ -1,6 +1,6 @@
 import ApprovalSvgIcon from '../../../img/app-dark.svg'
 import { Permission, FileAction } from '@nextcloud/files'
-import { onRequestAction } from '../helpers.js'
+import { onRequestFileAction } from '../helpers.js'
 
 export const requestAction = new FileAction({
 	id: 'approval-request',
@@ -20,7 +20,7 @@ export const requestAction = new FileAction({
 	iconSvgInline: () => ApprovalSvgIcon,
 	order: 1,
 	async exec(node) {
-		await onRequestAction(node)
+		await onRequestFileAction(node)
 		return null
 	},
 })

--- a/src/files/filesPlugin.js
+++ b/src/files/filesPlugin.js
@@ -7,12 +7,12 @@
  * See the COPYING-README file.
  *
  */
-import { createInfoModal, createRequestModal } from './modals.js'
+import { createInfoModal, createFilesRequestModal } from './modals.js'
 import { getUserRequesterRules } from './helpers.js'
 import '../bootstrap.js'
 
 createInfoModal()
-createRequestModal()
+createFilesRequestModal()
 
 // on page load: get rules that the current user is able to request with
 getUserRequesterRules().then((response) => {

--- a/src/files/helpers.js
+++ b/src/files/helpers.js
@@ -4,16 +4,15 @@ import { emit } from '@nextcloud/event-bus'
 import { showSuccess, showError, showWarning } from '@nextcloud/dialogs'
 import { set as vueSet } from 'vue'
 
-export async function getApprovalState(node) {
-	const url = generateOcsUrl('apps/approval/api/v1/state/' + node.fileid)
+export async function getApprovalState(fileId) {
+	const url = generateOcsUrl('apps/approval/api/v1/state/{fileId}', { fileId })
 	return await axios.get(url)
 }
 
 export async function updateNodeApprovalState(node) {
 	try {
-		const response = await getApprovalState(node)
-		const state = response.data.ocs.data.state
-		vueSet(node.attributes, 'approval-state', state)
+		const response = await getApprovalState(node.fileid)
+		vueSet(node.attributes, 'approval-state', response.data.ocs.data.state)
 		vueSet(node.attributes, 'approval-rule', response.data.ocs.data.rule)
 		vueSet(node.attributes, 'approval-timestamp', response.data.ocs.data.timestamp)
 		vueSet(node.attributes, 'approval-userId', response.data.ocs.data.userId)
@@ -27,9 +26,7 @@ export async function updateNodeApprovalState(node) {
 	}
 }
 
-export async function requestApproval(node, ruleId, createShares) {
-	const fileId = node.fileid
-	const fileName = node.basename
+export async function requestApproval(fileId, fileName, ruleId, createShares, node = null) {
 	const req = {
 		createShares,
 	}
@@ -37,15 +34,17 @@ export async function requestApproval(node, ruleId, createShares) {
 	try {
 		const response = await axios.post(url, req)
 		if (createShares) {
-			await requestAfterShareCreation(node, ruleId)
+			await requestAfterShareCreation(fileId, fileName, ruleId, node)
 		} else {
 			showSuccess(t('approval', 'Approval requested for {name}', { name: fileName }))
 			if (response.data?.ocs?.data?.warning) {
 				showWarning(t('approval', 'Warning') + ': ' + response.data.ocs.data.warning)
 			}
-			await updateNodeApprovalState(node)
-			// TODO
-			// reloadTags()
+			if (node) {
+				await updateNodeApprovalState(node)
+				// TODO
+				// reloadTags()
+			}
 		}
 	} catch (error) {
 		showError(
@@ -56,9 +55,7 @@ export async function requestApproval(node, ruleId, createShares) {
 	}
 }
 
-export async function requestAfterShareCreation(node, ruleId) {
-	const fileId = node.fileid
-	const fileName = node.basename
+export async function requestAfterShareCreation(fileId, fileName, ruleId, node = null) {
 	const req = {
 		createShares: false,
 	}
@@ -69,9 +66,11 @@ export async function requestAfterShareCreation(node, ruleId) {
 		if (response.data?.ocs?.data?.warning) {
 			showWarning(t('approval', 'Warning') + ': ' + response.data.ocs.data.warning)
 		}
-		await updateNodeApprovalState(node)
-		// TODO
-		// reloadTags()
+		if (node) {
+			await updateNodeApprovalState(node)
+			// TODO
+			// reloadTags()
+		}
 	} catch (error) {
 		showError(
 			t('approval', 'Failed to request approval for {name}', { name: fileName })
@@ -135,12 +134,12 @@ export async function getUserRequesterRules(fileId = null) {
 export async function onRequestAction(node) {
 	const fileId = node.fileid
 	const fileName = node.basename
-	OCA.Approval.RequestModalVue.showModal()
+	OCA.Approval.FilesRequestModalVue.showModal()
 	// refresh request rules when opening request modal
 	try {
 		const response = await getUserRequesterRules(fileId)
-		OCA.Approval.RequestModalVue.setUserRules(response.data.ocs.data)
-		OCA.Approval.RequestModalVue.setNode(node)
+		OCA.Approval.FilesRequestModalVue.setUserRules(response.data.ocs.data)
+		OCA.Approval.FilesRequestModalVue.setNode(node)
 		OCA.Approval.userRules = response.data.ocs.data
 	} catch (error) {
 		console.error(error)

--- a/src/files/helpers.js
+++ b/src/files/helpers.js
@@ -79,16 +79,16 @@ export async function requestAfterShareCreation(fileId, fileName, ruleId, node =
 	}
 }
 
-export async function onApproveAction(node, notify = true) {
-	const fileId = node.fileid
-	const fileName = node.basename
+export async function approve(fileId, fileName, node = null, notify = true) {
 	const url = generateOcsUrl('apps/approval/api/v1/approve/{fileId}', { fileId })
 	try {
 		await axios.put(url)
 		if (notify) {
 			showSuccess(t('approval', 'You approved {name}', { name: fileName }))
 		}
-		await updateNodeApprovalState(node)
+		if (node) {
+			await updateNodeApprovalState(node)
+		}
 	} catch (error) {
 		console.error(error)
 		if (notify) {
@@ -98,16 +98,16 @@ export async function onApproveAction(node, notify = true) {
 	}
 }
 
-export async function onRejectAction(node, notify = true) {
-	const fileId = node.fileid
-	const fileName = node.basename
+export async function reject(fileId, fileName, node = null, notify = true) {
 	const url = generateOcsUrl('apps/approval/api/v1/reject/{fileId}', { fileId })
 	try {
 		await axios.put(url)
 		if (notify) {
 			showSuccess(t('approval', 'You rejected {name}', { name: fileName }))
 		}
-		await updateNodeApprovalState(node)
+		if (node) {
+			await updateNodeApprovalState(node)
+		}
 	} catch (error) {
 		console.error(error)
 		if (notify) {
@@ -131,7 +131,7 @@ export async function getUserRequesterRules(fileId = null) {
 		: await axios.get(url, req)
 }
 
-export async function onRequestAction(node) {
+export async function onRequestFileAction(node) {
 	const fileId = node.fileid
 	const fileName = node.basename
 	OCA.Approval.FilesRequestModalVue.showModal()

--- a/src/files/modals.js
+++ b/src/files/modals.js
@@ -1,6 +1,6 @@
 import FilesRequestModal from '../components/FilesRequestModal.vue'
 import InfoModal from '../components/InfoModal.vue'
-import { requestApproval, onApproveAction, onRejectAction, onRequestAction } from './helpers.js'
+import { requestApproval, approve, reject, onRequestFileAction } from './helpers.js'
 import Vue from 'vue'
 
 export function createFilesRequestModal() {
@@ -33,12 +33,12 @@ export function createInfoModal() {
 		console.debug('[Approval] modal closed')
 	})
 	OCA.Approval.InfoModalVue.$on('approve', (node) => {
-		onApproveAction(node)
+		approve(node.fileid, node.basename, node)
 	})
 	OCA.Approval.InfoModalVue.$on('reject', (node) => {
-		onRejectAction(node)
+		reject(node.fileid, node.basename, node)
 	})
 	OCA.Approval.InfoModalVue.$on('request', (node) => {
-		onRequestAction(node)
+		onRequestFileAction(node)
 	})
 }

--- a/src/files/modals.js
+++ b/src/files/modals.js
@@ -1,22 +1,22 @@
-import RequestModal from '../components/RequestModal.vue'
+import FilesRequestModal from '../components/FilesRequestModal.vue'
 import InfoModal from '../components/InfoModal.vue'
 import { requestApproval, onApproveAction, onRejectAction, onRequestAction } from './helpers.js'
 import Vue from 'vue'
 
-export function createRequestModal() {
-	const requestModalId = 'requestApprovalModal'
-	const requestModalElement = document.createElement('div')
-	requestModalElement.id = requestModalId
-	document.body.append(requestModalElement)
+export function createFilesRequestModal() {
+	const filesRequestModalId = 'filesRequestApprovalModal'
+	const filesRequestModalElement = document.createElement('div')
+	filesRequestModalElement.id = filesRequestModalId
+	document.body.append(filesRequestModalElement)
 
-	const RequestModalView = Vue.extend(RequestModal)
-	OCA.Approval.RequestModalVue = new RequestModalView().$mount(requestModalElement)
+	const FilesRequestModalView = Vue.extend(FilesRequestModal)
+	OCA.Approval.FilesRequestModalVue = new FilesRequestModalView().$mount(filesRequestModalElement)
 
-	OCA.Approval.RequestModalVue.$on('close', () => {
+	OCA.Approval.FilesRequestModalVue.$on('close', () => {
 		console.debug('[Approval] modal closed')
 	})
-	OCA.Approval.RequestModalVue.$on('request', (node, ruleId, createShares) => {
-		requestApproval(node, ruleId, createShares)
+	OCA.Approval.FilesRequestModalVue.$on('request', (node, ruleId, createShares) => {
+		requestApproval(node.fileid, node.basename, ruleId, createShares, node)
 	})
 }
 

--- a/src/views/ApprovalTab.vue
+++ b/src/views/ApprovalTab.vue
@@ -24,11 +24,7 @@ import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import Info from '../components/Info.vue'
 import RequestModal from '../components/RequestModal.vue'
 
-import { getApprovalState, getUserRequesterRules, requestApproval } from '../files/helpers.js'
-
-import { generateOcsUrl } from '@nextcloud/router'
-import { showSuccess, showError } from '@nextcloud/dialogs'
-import axios from '@nextcloud/axios'
+import { getApprovalState, getUserRequesterRules, requestApproval, approve, reject } from '../files/helpers.js'
 
 export default {
 	name: 'ApprovalTab',
@@ -72,6 +68,7 @@ export default {
 
 	methods: {
 		update(fileInfo) {
+			console.debug('[Approval] sidebar tab update', fileInfo)
 			this.fileInfo = fileInfo
 			this.state = null
 			getApprovalState(fileInfo.id).then(response => {
@@ -94,33 +91,15 @@ export default {
 			this.state = null
 			const fileId = this.fileInfo.id
 			const fileName = this.fileInfo.name
-			const url = generateOcsUrl('apps/approval/api/v1/approve/{fileId}', { fileId })
-			try {
-				await axios.put(url)
-				showSuccess(t('approval', 'You approved {name}', { name: fileName }))
-				// await updateNodeApprovalState(node)
-				this.update(this.fileInfo)
-			} catch (error) {
-				console.error(error)
-				showError(t('approval', 'Failed to approve {name}', { name: fileName }))
-				throw error
-			}
+			await approve(fileId, fileName)
+			this.update(this.fileInfo)
 		},
 		async onReject() {
 			this.state = null
 			const fileId = this.fileInfo.id
 			const fileName = this.fileInfo.name
-			const url = generateOcsUrl('apps/approval/api/v1/reject/{fileId}', { fileId })
-			try {
-				await axios.put(url)
-				showSuccess(t('approval', 'You rejected {name}', { name: fileName }))
-				// await updateNodeApprovalState(node)
-				this.update(this.fileInfo)
-			} catch (error) {
-				console.error(error)
-				showError(t('approval', 'Failed to reject {name}', { name: fileName }))
-				throw error
-			}
+			await reject(fileId, fileName)
+			this.update(this.fileInfo)
 		},
 		async onRequestSubmit(ruleId, createShares) {
 			this.showRequestModal = false

--- a/src/views/ApprovalTab.vue
+++ b/src/views/ApprovalTab.vue
@@ -1,0 +1,136 @@
+<template>
+	<div>
+		<NcLoadingIcon v-if="state === null" />
+		<Info v-else
+			:state="state"
+			:timestamp="timestamp"
+			:user-name="userName"
+			:user-id="userId"
+			:rule="rule"
+			:user-rules="userRules"
+			@approve="onApprove"
+			@reject="onReject"
+			@request="showRequestModal = true" />
+		<RequestModal v-if="showRequestModal"
+			:user-rules="userRules"
+			@request="onRequestSubmit"
+			@close="showRequestModal = false" />
+	</div>
+</template>
+
+<script>
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
+
+import Info from '../components/Info.vue'
+import RequestModal from '../components/RequestModal.vue'
+
+import { getApprovalState, getUserRequesterRules, requestApproval } from '../files/helpers.js'
+
+import { generateOcsUrl } from '@nextcloud/router'
+import { showSuccess, showError } from '@nextcloud/dialogs'
+import axios from '@nextcloud/axios'
+
+export default {
+	name: 'ApprovalTab',
+
+	components: {
+		RequestModal,
+		Info,
+		NcLoadingIcon,
+	},
+
+	props: {
+	},
+
+	data() {
+		return {
+			fileInfo: null,
+			state: null,
+			timestamp: null,
+			userName: null,
+			userId: null,
+			rule: null,
+			userRules: [],
+			showRequestModal: false,
+		}
+	},
+
+	computed: {
+	},
+
+	watch: {
+	},
+
+	beforeDestroy() {
+	},
+
+	beforeMount() {
+	},
+
+	mounted() {
+	},
+
+	methods: {
+		update(fileInfo) {
+			this.fileInfo = fileInfo
+			this.state = null
+			getApprovalState(fileInfo.id).then(response => {
+				this.state = response.data.ocs.data.state
+				this.timestamp = response.data.ocs.data.timestamp
+				this.userId = response.data.ocs.data.userId
+				this.userName = response.data.ocs.data.userName
+				this.rule = response.data.ocs.data.rule
+			}).catch(error => {
+				console.error(error)
+			})
+			this.updateUserRules(fileInfo.id)
+		},
+		updateUserRules(fileId) {
+			getUserRequesterRules(fileId).then(response => {
+				this.userRules = response.data.ocs.data
+			})
+		},
+		async onApprove() {
+			this.state = null
+			const fileId = this.fileInfo.id
+			const fileName = this.fileInfo.name
+			const url = generateOcsUrl('apps/approval/api/v1/approve/{fileId}', { fileId })
+			try {
+				await axios.put(url)
+				showSuccess(t('approval', 'You approved {name}', { name: fileName }))
+				// await updateNodeApprovalState(node)
+				this.update(this.fileInfo)
+			} catch (error) {
+				console.error(error)
+				showError(t('approval', 'Failed to approve {name}', { name: fileName }))
+				throw error
+			}
+		},
+		async onReject() {
+			this.state = null
+			const fileId = this.fileInfo.id
+			const fileName = this.fileInfo.name
+			const url = generateOcsUrl('apps/approval/api/v1/reject/{fileId}', { fileId })
+			try {
+				await axios.put(url)
+				showSuccess(t('approval', 'You rejected {name}', { name: fileName }))
+				// await updateNodeApprovalState(node)
+				this.update(this.fileInfo)
+			} catch (error) {
+				console.error(error)
+				showError(t('approval', 'Failed to reject {name}', { name: fileName }))
+				throw error
+			}
+		},
+		async onRequestSubmit(ruleId, createShares) {
+			this.showRequestModal = false
+			await requestApproval(this.fileInfo.id, this.fileInfo.name, ruleId, createShares)
+			this.update(this.fileInfo)
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+// nothing yet
+</style>

--- a/tests/stubs/oc_hooks_emitter.php
+++ b/tests/stubs/oc_hooks_emitter.php
@@ -13,4 +13,7 @@ namespace OC\Hooks {
 namespace OCA\Files\Event {
 	class LoadAdditionalScriptsEvent extends \OCP\EventDispatcher\Event {
 	}
+
+	class LoadSidebar extends \OCP\EventDispatcher\Event {
+	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,7 @@ webpackConfig.entry = {
 	adminSettings: { import: path.join(__dirname, 'src', 'adminSettings.js'), filename: appId + '-adminSettings.js' },
 	dashboardPending: { import: path.join(__dirname, 'src', 'dashboardPending.js'), filename: appId + '-dashboardPending.js' },
 	filesPlugin: { import: path.join(__dirname, 'src', 'files/filesPlugin.js'), filename: appId + '-filesPlugin.js' },
+	approvalTab: { import: path.join(__dirname, 'src', 'approvalTab.js'), filename: appId + '-approvalTab.js' },
 	init: { import: path.join(__dirname, 'src', 'files/init.js'), filename: appId + '-init.js' },
 }
 


### PR DESCRIPTION
closes #158 

Some approval-related content was previously injected in the sidebar. This is not possible since NC 28.
It is still nice/important to see and change approval-related stuff in the sidebar, for example, when a file is opened in the viewer, we don't see the file list anymore.

This PR adds a basic sidebar tab that contains the same thing as the modal that opens when clicking the inline approval status in a file list item.

* Modal after inline status click (was there before):
![image](https://github.com/nextcloud/approval/assets/11291457/cb1bab5d-7b5f-4d18-bef4-e3ebba41d4cb)

* Sidebar tab (new stuff):
![image](https://github.com/nextcloud/approval/assets/11291457/f37437ad-3a70-4ac6-bddc-3e2911a099a1)

@skjnldsv Slightly off-topic:
* Any way to ask for a file list item refresh when we don't have a reference to the node object? Something like `emit('files:node:updated', node)` but only knowing a file ID or file path.
* Any way to ask for a sidebar refresh? Looking for something to trigger all tab's `update(fileInfo)` method call.
