### PR TITLE
Fix empty approval files sidebar tab

### DIFF
--- a/src/components/Info.vue
+++ b/src/components/Info.vue
@@ -1,5 +1,15 @@
 <template>
 	<div class="info-content">
+		<NcButton v-if="canRequestApproval"
+			@click="onRequest">
+			<template #icon>
+				<CheckIcon :size="20" />
+			</template>
+			{{ t('approval', 'Request approval') }}
+		</NcButton>
+		<div v-else-if="stateNothing">
+			{{ t('approval', 'There is no approval workflow allowing you to request approval.') }}
+		</div>
 		<ApprovalButtons v-if="stateApprovable"
 			class="buttons"
 			:approve-text="approveText"
@@ -51,13 +61,6 @@
 			</span>
 			<span v-else>{{ pendingTextWithTime }}</span>
 		</span>
-		<NcButton v-if="canRequestApproval"
-			@click="onRequest">
-			<template #icon>
-				<CheckIcon :size="20" />
-			</template>
-			{{ t('approval', 'Request approval') }}
-		</NcButton>
 		<div class="info">
 			<span>{{ infoText }}</span>
 			<NcUserBubble v-if="stateApprovable && userName"
@@ -181,6 +184,9 @@ export default {
 		},
 		stateApprovable() {
 			return this.state === states.APPROVABLE
+		},
+		stateNothing() {
+			return this.state === states.NOTHING
 		},
 		relativeTime() {
 			return moment.unix(this.timestamp).fromNow()


### PR DESCRIPTION
closes #194

I assume the issue in #194 is that if there is no workflow configured, the approval tab is empty. Right @ChristophWurst?

There is now a message if it's not possible to request approval or approve/reject.