### PR TITLE
prepare 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 2.1.0 – 2025-01-09
+
+### Changed
+
+- Support Nextcloud 31
+
+### Fixed
+
+- Request action icon was black in dark theme @julien-nc [#228](https://github.com/nextcloud/approval/pull/228)
+- Notifications: Notifier::prepare() threw \InvalidArgumentException which is deprecated @nickvergessen [#249](https://github.com/nextcloud/approval/pull/249)
+
 ## 2.0.0 – 2024-07-23
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@ Approve/reject files based on workflows defined by admins.
 **Warning**: The DocuSign integration is no longer part of this app
 and can be installed with [this app](https://apps.nextcloud.com/apps/integration_docusign).
 ]]></description>
-	<version>2.0.0</version>
+	<version>2.1.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Approval</namespace>


### PR DESCRIPTION
### Changed

- Support Nextcloud 31

### Fixed

- Request action icon was black in dark theme @julien-nc [#228](https://github.com/nextcloud/approval/pull/228)
- Notifications: Notifier::prepare() threw \InvalidArgumentException which is deprecated @nickvergessen [#249](https://github.com/nextcloud/approval/pull/249)