### PR TITLE
create restricted instead of invisible tags in approval settings

### DIFF
--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -40,6 +40,7 @@ class ConfigController extends Controller {
 	 * @param string $name of the new tag
 	 * @return DataResponse
 	 */
+	#[AuthorizedAdminSetting(settings: Admin::class)]
 	public function createTag(string $name): DataResponse {
 		$result = $this->utilsService->createTag($name);
 		if (isset($result['error'])) {

--- a/lib/Service/UtilsService.php
+++ b/lib/Service/UtilsService.php
@@ -172,7 +172,7 @@ class UtilsService {
 	 */
 	public function createTag(string $name): array {
 		try {
-			$tag = $this->tagManager->createTag($name, false, false);
+			$tag = $this->tagManager->createTag($name, true, false);
 			return ['id' => $tag->getId()];
 		} catch (TagAlreadyExistsException $e) {
 			return ['error' => 'Tag already exists'];

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -10,17 +10,12 @@ namespace OCA\Approval\Settings;
 use OCA\Approval\AppInfo\Application;
 use OCP\AppFramework\Http\TemplateResponse;
 
-use OCP\AppFramework\Services\IInitialState;
-use OCP\IGroupManager;
 use OCP\Settings\IDelegatedSettings;
 
 class Admin implements IDelegatedSettings {
 
 	public function __construct(
 		private string $appName,
-		private IGroupManager $groupManager,
-		private IInitialState $initialStateService,
-		private ?string $userId,
 	) {
 	}
 
@@ -28,7 +23,6 @@ class Admin implements IDelegatedSettings {
 	 * @return TemplateResponse
 	 */
 	public function getForm(): TemplateResponse {
-		$this->initialStateService->provideInitialState('is-admin', $this->groupManager->isAdmin($this->userId));
 		return new TemplateResponse(Application::APP_ID, 'adminSettings');
 	}
 

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -30,7 +30,6 @@
 				<ApprovalRule v-for="(rule, id) in rules"
 					:key="id"
 					v-model:value="rules[id]"
-					:is-admin="isAdmin"
 					class="approval-rule"
 					@input="onRuleInput(id, $event)"
 					@add-tag="onAddTagClick">
@@ -55,7 +54,6 @@
 				<div v-if="newRule" class="new-rule">
 					<ApprovalRule
 						v-model:value="newRule"
-						:is-admin="isAdmin"
 						:delete-rule-label="newRuleDeleteLabel"
 						:focus="true"
 						@add-tag="onAddTagClick">
@@ -91,10 +89,10 @@
 				</template>
 				{{ t('approval', 'New workflow') }}
 			</NcButton>
-			<div v-if="isAdmin" class="create-tag">
+			<div class="create-tag">
 				<label for="create-tag-input">
 					<TagIcon :size="16" />
-					{{ t('approval', 'Create new hidden tag') }}
+					{{ t('approval', 'Create new restricted tag') }}
 				</label>
 				<input id="create-tag-input"
 					ref="createTagInput"
@@ -129,7 +127,6 @@ import ApprovalRule from './ApprovalRule.vue'
 import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 import { showSuccess, showError } from '@nextcloud/dialogs'
-import { loadState } from '@nextcloud/initial-state'
 
 export default {
 	name: 'AdminSettings',
@@ -148,7 +145,6 @@ export default {
 
 	data() {
 		return {
-			isAdmin: loadState('approval', 'is-admin'),
 			showRules: true,
 			newTagName: '',
 			rules: {},

--- a/src/components/ApprovalRule.vue
+++ b/src/components/ApprovalRule.vue
@@ -22,7 +22,6 @@
 					{{ pendingLabel }}
 					<div class="spacer" />
 					<span
-						v-if="isAdmin"
 						:title="t('approval', 'Create new hidden tag')"
 						class="add-tag-button"
 						@click="$emit('add-tag')">
@@ -75,7 +74,6 @@
 					{{ approvedLabel }}
 					<div class="spacer" />
 					<span
-						v-if="isAdmin"
 						:title="t('approval', 'Create new hidden tag')"
 						class="add-tag-button"
 						@click="$emit('add-tag')">
@@ -99,7 +97,6 @@
 					{{ rejectedLabel }}
 					<div class="spacer" />
 					<span
-						v-if="isAdmin"
 						:title="t('approval', 'Create new hidden tag')"
 						class="add-tag-button"
 						@click="$emit('add-tag')">
@@ -162,10 +159,6 @@ export default {
 		focus: {
 			type: Boolean,
 			default: false,
-		},
-		isAdmin: {
-			type: Boolean,
-			default: true,
 		},
 	},
 


### PR DESCRIPTION
This allows the tag to be visible to users and used in an approval flow by delegated admins.