### PR TITLE
Prepare 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## 1.3.1 – 2025-10-08
+
+### Fixed
+
+- File ownership [#334](https://github.com/nextcloud/approval/pull/334) @lukasdotcom
 
 ## 1.3.0 – 2024-05-29
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@ Approve/reject files based on workflows defined by admins.
 **Warning**: The DocuSign integration is no longer part of this app
 and can be installed with [this app](https://apps.nextcloud.com/apps/integration_docusign).
 ]]></description>
-	<version>1.3.0</version>
+	<version>1.3.1</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Approval</namespace>


### PR DESCRIPTION
## 1.3.1 – 2025-10-08

### Fixed

- File ownership [#334](https://github.com/nextcloud/approval/pull/334) @lukasdotcom