### PR TITLE
Prepare 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.6.0 - 2025-11-03
+
+### Added
+
+- Support for nextcloud 33 and migrate away from IConfig @lukasdotcom [#338](https://github.com/nextcloud/approval/pull/338)
+
+### Fixed
+
+- Improve performance of getApprovalState when there are a lot of rules @lukasdotcom [#340](https://github.com/nextcloud/approval/pull/340)
+- Store approval and rejection message before changing state of tags @lukasdotcom [#341](https://github.com/nextcloud/approval/pull/341)
+
 ## 2.5.0 - 2025-10-08
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@ Approve/reject files based on workflows defined by admins.
 **Warning**: The DocuSign integration is no longer part of this app
 and can be installed with [this app](https://apps.nextcloud.com/apps/integration_docusign).
 ]]></description>
-	<version>2.5.0</version>
+	<version>2.6.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Approval</namespace>


### PR DESCRIPTION
## 2.6.0 - 2025-11-03

### Added

- Support for nextcloud 33 and migrate away from IConfig @lukasdotcom [#338](https://github.com/nextcloud/approval/pull/338)

### Fixed

- Improve performance of getApprovalState when there are a lot of rules @lukasdotcom [#340](https://github.com/nextcloud/approval/pull/340)
- Store approval and rejection message before changing state of tags @lukasdotcom [#341](https://github.com/nextcloud/approval/pull/341)