### PR TITLE
Prepare 2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.7.1 - 2026-01-23
+
+### Fixed
+
+- Add better error message on users side for failed approval @lukasdotcom [#366](https://github.com/nextcloud/approval/pull/366)
+
 ## 2.7.0 - 2026-01-08
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@ Approve/reject files based on workflows defined by admins.
 **Warning**: The DocuSign integration is no longer part of this app
 and can be installed with [this app](https://apps.nextcloud.com/apps/integration_docusign).
 ]]></description>
-	<version>2.7.0</version>
+	<version>2.7.1</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Approval</namespace>


### PR DESCRIPTION
## 2.7.1 - 2026-01-23

### Fixed

- Add better error message on users side for failed approval @lukasdotcom [#366](https://github.com/nextcloud/approval/pull/366)