### PR TITLE
fix: Ensure rich parameters are strings

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -68,14 +68,14 @@ class Notifier implements INotifier {
 				if ($user instanceof IUser) {
 					$richSubjectUser = [
 						'type' => 'user',
-						'id' => $p['approverId'],
+						'id' => (string)$p['approverId'],
 						'name' => $user->getDisplayName(),
 					];
 
 					$linkToFile = $this->url->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileid' => $p['fileId']]);
 					$richSubjectNode = [
 						'type' => 'file',
-						'id' => $p['fileId'],
+						'id' => (string)$p['fileId'],
 						'name' => $p['fileName'],
 						'path' => trim($p['relativePath'], '/'),
 						'link' => $linkToFile,
@@ -122,14 +122,14 @@ class Notifier implements INotifier {
 				if ($user instanceof IUser) {
 					$richSubjectUser = [
 						'type' => 'user',
-						'id' => $p['requesterId'],
+						'id' => (string)$p['requesterId'],
 						'name' => $user->getDisplayName(),
 					];
 
 					$linkToFile = $this->url->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileid' => $p['fileId']]);
 					$richSubjectNode = [
 						'type' => 'file',
-						'id' => $p['fileId'],
+						'id' => (string)$p['fileId'],
 						'name' => $p['fileName'],
 						'path' => trim($p['relativePath'], '/'),
 						'link' => $linkToFile,


### PR DESCRIPTION
Noticed while testing https://github.com/nextcloud/approval/pull/389.

> Notification was claimed to be parsed, but was not fully parsed by OCA\\Approval\\Notification\\Notifier [app: approval, subject: manual_request]