### PR TITLE
Prepare 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.0 – 2026-03-16
+
+### Added
+
+- Only share to users and groups when necessary [#389](https://github.com/nextcloud/approval/pull/389) @lukasdotcom
+- Add support for Nextcloud 34
+
+### Changed
+
+- Implement typescript [#381](https://github.com/nextcloud/approval/pull/381) @lukasdotcom
+
+### Fixed
+
+- Improve testing [#392](https://github.com/nextcloud/approval/pull/392) @lukasdotcom
+- Ensure rich parameters are strings [#391](https://github.com/nextcloud/approval/pull/391) @SystemKeeper
+- Update README.md [#387](https://github.com/nextcloud/approval/pull/387) @Jerome-Herbinet
+- Hide batch action for respondAction [#382](https://github.com/nextcloud/approval/pull/382) @lukasdotcom
+- FileAction class was removed from @nextcloud/files [#380](https://github.com/nextcloud/approval/pull/380) @julien-nc
+- Show selected tags in workflow admin / Fix workflow when manually triggered via tag assignment [#376](https://github.com/nextcloud/approval/pull/376) @kesselb
+- Replace getById with getFirstNodeById [#375](https://github.com/nextcloud/approval/pull/375) @CarlSchwan
+
 ## 3.1.0 - 2026-01-23
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@ Approve/reject files based on workflows defined by admins.
 **Warning**: The DocuSign integration is no longer part of this app
 and can be installed with [this app](https://apps.nextcloud.com/apps/integration_docusign).
 ]]></description>
-	<version>3.1.0</version>
+	<version>3.2.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Approval</namespace>
@@ -32,7 +32,7 @@ and can be installed with [this app](https://apps.nextcloud.com/apps/integration
 	<screenshot>https://github.com/nextcloud/approval/raw/main/img/screenshot_2.jpg</screenshot>
 	<screenshot>https://github.com/nextcloud/approval/raw/main/img/screenshot_3.jpg</screenshot>
 	<dependencies>
-		<nextcloud min-version="33" max-version="33"/>
+		<nextcloud min-version="33" max-version="34"/>
 	</dependencies>
 	<settings>
 		<admin>OCA\Approval\Settings\Admin</admin>

--- a/lib/Service/ApprovalService.php
+++ b/lib/Service/ApprovalService.php
@@ -868,8 +868,8 @@ class ApprovalService {
 	 */
 	public function removeApprovalTags(Node $file): void {
 		$fileId = $file->getId();
-		$fileTags = $this->tagObjectMapper->getTagIdsForObjects([$fileId], 'files');
-		$fileTags = $fileTags[$fileId] ?? [];
+		$fileTags = $this->tagObjectMapper->getTagIdsForObjects([(string)$fileId], 'files');
+		$fileTags = $fileTags[(string)$fileId] ?? [];
 		if (count($fileTags) > 0) {
 			$tags = $this->ruleService->filterApprovalTags($fileTags);
 			foreach ($tags as $tag) {


### PR DESCRIPTION
## 3.2.0 – 2026-03-16

### Added

- Only share to users and groups when necessary [#389](https://github.com/nextcloud/approval/pull/389) @lukasdotcom
- Add support for Nextcloud 34

### Changed

- Implement typescript [#381](https://github.com/nextcloud/approval/pull/381) @lukasdotcom

### Fixed

- Improve testing [#392](https://github.com/nextcloud/approval/pull/392) @lukasdotcom
- Ensure rich parameters are strings [#391](https://github.com/nextcloud/approval/pull/391) @SystemKeeper
- Update README.md [#387](https://github.com/nextcloud/approval/pull/387) @Jerome-Herbinet
- Hide batch action for respondAction [#382](https://github.com/nextcloud/approval/pull/382) @lukasdotcom
- FileAction class was removed from @nextcloud/files [#380](https://github.com/nextcloud/approval/pull/380) @julien-nc
- Show selected tags in workflow admin / Fix workflow when manually triggered via tag assignment [#376](https://github.com/nextcloud/approval/pull/376) @kesselb
- Replace getById with getFirstNodeById [#375](https://github.com/nextcloud/approval/pull/375) @CarlSchwan