### PR TITLE
Prepare 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.3] - 2026-04-14
+
+### Changed
+
+- Change api signature to require etag [#403](https://github.com/nextcloud/approval/pull/403) @lukasdotcom
+
+### Fixed
+
+- Add better error message on users side for failed approval [#365](https://github.com/nextcloud/approval/pull/365) @lukasdotcom
+
 ## 1.3.2 – 2026-03-16
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@ Approve/reject files based on workflows defined by admins.
 **Warning**: The DocuSign integration is no longer part of this app
 and can be installed with [this app](https://apps.nextcloud.com/apps/integration_docusign).
 ]]></description>
-	<version>1.3.2</version>
+	<version>1.3.3</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Approval</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "approval",
-  "version": "1.0.12",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "approval",
-      "version": "1.0.12",
+      "version": "1.3.3",
       "license": "AGPL-3.0",
       "dependencies": {
         "@mdi/svg": "^7.3.67",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "approval",
-  "version": "1.0.12",
+  "version": "1.3.3",
   "description": "Approval",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## [1.3.3] - 2026-04-14

### Changed

- Change api signature to require etag [#403](https://github.com/nextcloud/approval/pull/403) @lukasdotcom

### Fixed

- Add better error message on users side for failed approval [#365](https://github.com/nextcloud/approval/pull/365) @lukasdotcom