### PR TITLE
Prepare 2.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.7.3 - 2026-04-14
+
+### Changed
+
+- Change api signature to require etag [#403](https://github.com/nextcloud/approval/pull/403) @lukasdotcom
+
+### Fixed
+
+- Only share to users and groups when necessary [#389](https://github.com/nextcloud/approval/pull/389) @lukasdotcom
+
 ## 2.7.2 – 2026-03-16
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@ Approve/reject files based on workflows defined by admins.
 **Warning**: The DocuSign integration is no longer part of this app
 and can be installed with [this app](https://apps.nextcloud.com/apps/integration_docusign).
 ]]></description>
-	<version>2.7.2</version>
+	<version>2.7.3</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Approval</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "approval",
-  "version": "1.0.12",
+  "version": "2.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "approval",
-      "version": "1.0.12",
+      "version": "2.7.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.3.67",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "approval",
-  "version": "1.0.12",
+  "version": "2.7.3",
   "description": "Approval",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## 2.7.3 - 2026-04-14

### Changed

- Change api signature to require etag [#403](https://github.com/nextcloud/approval/pull/403) @lukasdotcom

### Fixed

- Only share to users and groups when necessary [#389](https://github.com/nextcloud/approval/pull/389) @lukasdotcom