### PR TITLE
Prepare 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.1 - 2026-04-14
+
+### Changed
+
+- Change api signature to require etag [#403](https://github.com/nextcloud/approval/pull/403) @lukasdotcom
+
+### Fixed
+
+- Prevent re-requesting approval for already approved files [#399](https://github.com/nextcloud/approval/pull/399) @Amitdwivedi22
+- Fix grammar in error message for file sharing [#400](https://github.com/nextcloud/approval/pull/400) @rakekniven
+
 ## 3.2.0 – 2026-03-16
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@ Approve/reject files based on workflows defined by admins.
 **Warning**: The DocuSign integration is no longer part of this app
 and can be installed with [this app](https://apps.nextcloud.com/apps/integration_docusign).
 ]]></description>
-	<version>3.2.0</version>
+	<version>3.2.1</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Approval</namespace>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "approval",
-  "version": "1.0.12",
+  "version": "3.2.1",
   "description": "Approval",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## 3.2.1 - 2026-04-14

### Changed

- Change api signature to require etag [#403](https://github.com/nextcloud/approval/pull/403) @lukasdotcom

### Fixed

- Prevent re-requesting approval for already approved files [#399](https://github.com/nextcloud/approval/pull/399) @Amitdwivedi22
- Fix grammar in error message for file sharing [#400](https://github.com/nextcloud/approval/pull/400) @rakekniven