### PR TITLE
Share as the requester, not as the owner

### DIFF
--- a/lib/Service/ApprovalService.php
+++ b/lib/Service/ApprovalService.php
@@ -440,18 +440,18 @@ class ApprovalService {
 	 *
 	 * @param int $fileId
 	 * @param int $ruleId
-	 * @param string|null $userId
+	 * @param string|null $requesterUserId
 	 * @param bool $createShares
 	 * @return array potential error message
 	 * @throws \OCP\Files\NotPermittedException
 	 * @throws \OC\User\NoUserException
 	 */
-	public function request(int $fileId, int $ruleId, ?string $userId, bool $createShares): array {
-		if (!$this->utilsService->userHasAccessTo($fileId, $userId)) {
+	public function request(int $fileId, int $ruleId, ?string $requesterUserId, bool $createShares): array {
+		if (!$this->utilsService->userHasAccessTo($fileId, $requesterUserId)) {
 			return ['error' => $this->l10n->t('You do not have access to this file')];
 		}
 
-		if ($createShares && !$this->utilsService->userCanShareFile($fileId, $userId)) {
+		if ($createShares && !$this->utilsService->userCanShareFile($fileId, $requesterUserId)) {
 			return ['error' => $this->l10n->t('You cannot share this file')];
 		}
 
@@ -460,19 +460,19 @@ class ApprovalService {
 			return ['error' => $this->l10n->t('Rule does not exist')];
 		}
 
-		if ($this->userIsAuthorizedByRule($userId, $rule, 'requesters')) {
+		if ($this->userIsAuthorizedByRule($requesterUserId, $rule, 'requesters')) {
 			if ($this->tagObjectMapper->haveTag((string)$fileId, 'files', $rule['tagApproved'])) {
 				return ['error' => $this->l10n->t('Approval has already been granted with this rule for this file')];
 			}
 			// only request if it has not yet been requested for this rule
 			if (!$this->tagObjectMapper->haveTag((string)$fileId, 'files', $rule['tagPending'])) {
 				if ($createShares) {
-					$this->shareWithApprovers($fileId, $rule, $userId);
+					$this->shareWithApprovers($fileId, $rule, $requesterUserId);
 					// if shares are auto created, request is actually done in a separated request with $createShares === false
 					return [];
 				}
 				// store activity in our tables
-				$this->ruleService->storeAction($fileId, $ruleId, $userId, Application::STATE_PENDING);
+				$this->ruleService->storeAction($fileId, $ruleId, $requesterUserId, Application::STATE_PENDING);
 
 				$this->tagObjectMapper->assignTags((string)$fileId, 'files', $rule['tagPending']);
 
@@ -480,7 +480,7 @@ class ApprovalService {
 				$this->activityManager->triggerEvent(
 					ActivityManager::APPROVAL_OBJECT_NODE, $fileId,
 					ActivityManager::SUBJECT_REQUESTED_ORIGIN,
-					['origin_user_id' => $userId]
+					['origin_user_id' => $requesterUserId]
 				);
 
 				// check if someone can actually approve
@@ -535,27 +535,19 @@ class ApprovalService {
 	 *
 	 * @param int $fileId
 	 * @param Rule $rule
-	 * @param string $userId
+	 * @param string $requesterUserId
 	 * @return void
 	 * @throws \OCP\Files\NotPermittedException
 	 * @throws \OC\User\NoUserException
 	 */
-	private function shareWithApprovers(int $fileId, array $rule, string $userId): void {
+	private function shareWithApprovers(int $fileId, array $rule, string $requesterUserId): void {
 		// get node
-		$userFolder = $this->root->getUserFolder($userId);
+		$userFolder = $this->root->getUserFolder($requesterUserId);
 		$node = $userFolder->getFirstNodeById($fileId);
 		if ($node === null) {
 			return;
 		}
-		// get the node again from the owner's storage to avoid sharing permission issues
-		$ownerId = $node->getOwner()->getUID();
-		$ownerFolder = $this->root->getUserFolder($ownerId);
-		$ownerNode = $ownerFolder->getFirstNodeById($fileId);
-		if ($ownerNode !== null) {
-			$node = $ownerNode;
-		}
 		$label = $this->l10n->t('Please check my approval request');
-		$fileOwner = $node->getOwner()->getUID();
 
 		// Gets all users that have access to the file
 		$mounts = $this->userMountCache->getMountsForFileId($fileId);
@@ -564,7 +556,7 @@ class ApprovalService {
 		foreach ($rule['approvers'] as $approver) {
 			if ($approver['type'] === 'user' && !in_array($approver['entityId'], $userIdsWithAccess, true)) {
 				// create user share
-				if (!$this->utilsService->createShare($node, IShare::TYPE_USER, $approver['entityId'], $fileOwner, $label)) {
+				if (!$this->utilsService->createShare($node, IShare::TYPE_USER, $approver['entityId'], $requesterUserId, $label)) {
 					$this->logger->warning('Failed to create user share for file {fileId} with approver {approverId}', ['fileId' => $fileId, 'approverId' => $approver['entityId']]);
 				}
 			}
@@ -577,13 +569,13 @@ class ApprovalService {
 					$groupMembersThatNeedAccess = array_diff($groupMemberIds, $userIdsWithAccess);
 					// Create group share if everyone in the group needs access
 					if (count($groupMembersThatNeedAccess) === count($groupMemberIds)) {
-						if (!$this->utilsService->createShare($node, IShare::TYPE_GROUP, $approver['entityId'], $fileOwner, $label)) {
+						if (!$this->utilsService->createShare($node, IShare::TYPE_GROUP, $approver['entityId'], $requesterUserId, $label)) {
 							$this->logger->warning('Failed to create group share for file {fileId} with approver {approverId}', ['fileId' => $fileId, 'approverId' => $approver['entityId']]);
 						}
 					} elseif (count($groupMembersThatNeedAccess) > 0) {
 						// Create user shares for each member that needs access
 						foreach ($groupMembersThatNeedAccess as $groupMemberId) {
-							if (!$this->utilsService->createShare($node, IShare::TYPE_USER, $groupMemberId, $fileOwner, $label)) {
+							if (!$this->utilsService->createShare($node, IShare::TYPE_USER, $groupMemberId, $requesterUserId, $label)) {
 								$this->logger->warning('Failed to create user share for file {fileId} with approver {approverId}', ['fileId' => $fileId, 'approverId' => $groupMemberId]);
 							}
 						}
@@ -596,7 +588,7 @@ class ApprovalService {
 		if ($circlesEnabled) {
 			foreach ($rule['approvers'] as $approver) {
 				if ($approver['type'] === 'circle') {
-					if (!$this->utilsService->createShare($node, IShare::TYPE_CIRCLE, $approver['entityId'], $fileOwner, $label)) {
+					if (!$this->utilsService->createShare($node, IShare::TYPE_CIRCLE, $approver['entityId'], $requesterUserId, $label)) {
 						$this->logger->warning('Failed to create circle share for file {fileId} with approver {approverId}', ['fileId' => $fileId, 'approverId' => $approver['entityId']]);
 					}
 				}

--- a/lib/Service/UtilsService.php
+++ b/lib/Service/UtilsService.php
@@ -49,10 +49,8 @@ class UtilsService {
 	public function createShare(Node $node, int $type, string $sharedWith, string $sharedBy, string $label): bool {
 		$share = $this->shareManager->newShare();
 		$share->setNode($node)
-			// share permission is not necessary for rule chaining
-			// because we get the file from its owner's storage so we can share it whatsoever
-			// ->setPermissions(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE)
-			->setPermissions(Constants::PERMISSION_READ)
+			// share permission is necessary for rule chaining
+			->setPermissions(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE)
 			->setSharedWith($sharedWith)
 			->setShareType($type)
 			->setSharedBy($sharedBy)


### PR DESCRIPTION
We check if the requester is allowed to share. But later we still share as the file owner, not as the requester.
This fixes it.

Chaining rules still works because we share with the "sharing" permission now.