### PR TITLE
Prepare 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.8.0 - 2026-04-28
+
+### Fixed
+
+- Share as the requester, not as the owner [#420](https://github.com/nextcloud/approval/pull/420) @julien-nc
+- Fix grammar in error message for file sharing [#415](https://github.com/nextcloud/approval/pull/415) @rakekniven
 
 ## 2.7.4 - 2026-04-16
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@ Approve/reject files based on workflows defined by admins.
 **Warning**: The DocuSign integration is no longer part of this app
 and can be installed with [this app](https://apps.nextcloud.com/apps/integration_docusign).
 ]]></description>
-	<version>2.7.4</version>
+	<version>2.8.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Approval</namespace>


### PR DESCRIPTION
### Fixed

- Share as the requester, not as the owner [#420](https://github.com/nextcloud/approval/pull/420) @julien-nc
- Fix grammar in error message for file sharing [#415](https://github.com/nextcloud/approval/pull/415) @rakekniven