### PR TITLE
Prepare 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.3.0 - 2026-04-28
+
+### Fixed
+
+- Share as the requester, not as the owner [#418](https://github.com/nextcloud/approval/pull/418) @julien-nc
+- Fix(adminSettings): Avoid a crash when adding the first rule by reloading the rules each time we add one [#417](https://github.com/nextcloud/approval/pull/417) @julien-nc
+
 ## 3.2.2 - 2026-04-16
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@ Approve/reject files based on workflows defined by admins.
 **Warning**: The DocuSign integration is no longer part of this app
 and can be installed with [this app](https://apps.nextcloud.com/apps/integration_docusign).
 ]]></description>
-	<version>3.2.2</version>
+	<version>3.3.0</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Approval</namespace>


### PR DESCRIPTION
### Fixed

- Share as the requester, not as the owner [#418](https://github.com/nextcloud/approval/pull/418) @julien-nc
- Fix(adminSettings): Avoid a crash when adding the first rule by reloading the rules each time we add one [#417](https://github.com/nextcloud/approval/pull/417) @julien-nc