### PR TITLE
chore: Prepare 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.3.1 - 2026-07-23
+
+### Added
+
+- Add support for Nextcloud 35
+
+### Changed
+
+- Update dependencies and workflows [#440](https://github.com/nextcloud/approval/pull/440) @lukasdotcom
+
+### Fixed
+
+- Add warning when public tag used for rule and only load tags once for all rules [#437](https://github.com/nextcloud/approval/pull/437) @lukasdotcom
+
 ## 3.3.0 - 2026-04-28
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@ Approve/reject files based on workflows defined by admins.
 **Warning**: The DocuSign integration is no longer part of this app
 and can be installed with [this app](https://apps.nextcloud.com/apps/integration_docusign).
 ]]></description>
-	<version>3.3.0</version>
+	<version>3.3.1</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Approval</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "approval",
-  "version": "3.2.2",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "approval",
-      "version": "3.2.2",
+      "version": "3.3.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/svg": "^7.3.67",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "approval",
-  "version": "3.2.2",
+  "version": "3.3.1",
   "description": "Approval",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## 3.3.1 - 2026-07-23

### Added

- Add support for Nextcloud 35

### Changed

- Update dependencies and workflows [#440](https://github.com/nextcloud/approval/pull/440) @lukasdotcom

### Fixed

- Add warning when public tag used for rule and only load tags once for all rules [#437](https://github.com/nextcloud/approval/pull/437) @lukasdotcom